### PR TITLE
fix: Set call handling to not use base url as path

### DIFF
--- a/helperlib/src/main/java/com/itachi1706/helperlib/helpers/ApiCallsHelper.kt
+++ b/helperlib/src/main/java/com/itachi1706/helperlib/helpers/ApiCallsHelper.kt
@@ -142,6 +142,10 @@ class ApiCallsHelper(
             return this
         }
 
+        /**
+         * Set the path to use for API calls
+         * @param path Path to use for API calls
+         */
         fun setPath(path: String): Builder {
             this.path = path
             return this


### PR DESCRIPTION
The current implementation makes it such that the base url is also the path. As a result when using the builder pattern it will attempt to call `$baseUrl/$baseUrl` which is incorrect

This change converts the call to a new path variable so that it calls `$baseUrl/$path` correctly. And this path is optional and defaults to an empty string so that you can choose not to use it. 